### PR TITLE
Label skewness partion

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -1020,7 +1020,7 @@ def record_net_data_stats(y_train, net_dataidx_map):
         # If it doesn't exist, create it
         os.makedirs(directory)
         
-    figure.savefig(f'{directory}/heatmap.png', dpi=400)
+    #figure.savefig(f'{directory}/heatmap.png', dpi=400)
     
     #logger.info('Data statistics: %s' % str(net_cls_counts))
     #logger.info('Saved Data bins Heatmap')

--- a/datasets.py
+++ b/datasets.py
@@ -2,9 +2,26 @@ import random
 import numpy as np
 import torch
 import os
+import os.path
+from PIL import Image
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import torchvision
 from torch.utils.data import DataLoader, TensorDataset
+from torchvision.datasets import MNIST, CIFAR10, SVHN, FashionMNIST, CIFAR100, ImageFolder, DatasetFolder
 from torchvision import datasets, transforms
-#from torchaudio.datasets import SPEECHCOMMANDS
+import torchvision.transforms as transforms
+#from datasets import MNIST_truncated, CIFAR10_truncated, CIFAR100_truncated, ImageFolder_custom, SVHN_custom, FashionMNIST_truncated, CustomTensorDataset, CelebA_custom, FEMNIST, Generated, genData
+from math import sqrt
+from torch.autograd import Variable
+import torch.utils.data as data
+from typing import Optional, Callable
+from torchvision.datasets.utils import download_file_from_google_drive, check_integrity
+import tarfile
+import zipfile
+from torch.utils.model_zoo import tqdm
+import torch.nn.functional as F
 
 class Partition(object):
 
@@ -368,6 +385,16 @@ class SubsetSC(): #SPEECHCOMMANDS
             else:
                 self._walker = [w for w in self._walker if w not in excludes]
 
+def gen_bar_updater() -> Callable[[int, int, int], None]:
+    pbar = tqdm(total=None)
+
+    def bar_update(count, block_size, total_size):
+        if pbar.total is None and total_size:
+            pbar.total = total_size
+        progress_bytes = count * block_size
+        pbar.update(progress_bytes - pbar.n)
+
+    return bar_update
 
 def collate_fn(batch, labels):
 
@@ -392,3 +419,910 @@ def collate_fn(batch, labels):
     targets = torch.stack(targets)
 
     return tensors, targets
+class MNIST_truncated(data.Dataset):
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None, download=False):
+
+        self.root = root
+        self.dataidxs = dataidxs
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+        self.download = download
+
+        self.data, self.target = self.__build_truncated_dataset__()
+
+    def __build_truncated_dataset__(self):
+
+        mnist_dataobj = MNIST(self.root, self.train, self.transform, self.target_transform, self.download)
+
+        # if self.train:
+        #     data = mnist_dataobj.train_data
+        #     target = mnist_dataobj.train_labels
+        # else:
+        #     data = mnist_dataobj.test_data
+        #     target = mnist_dataobj.test_labels
+
+        data = mnist_dataobj.data
+        target = mnist_dataobj.targets
+
+        if self.dataidxs is not None:
+            data = data[self.dataidxs]
+            target = target[self.dataidxs]
+
+        return data, target
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index], self.target[index]
+
+        # doing this so that it is consistent with all other datasets
+        # to return a PIL Image
+        img = Image.fromarray(img.numpy(), mode='L')
+
+        # print("mnist img:", img)
+        # print("mnist target:", target)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+    
+# From NIID-bench
+def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None) -> None:
+    """Download a file from a url and place it in root.
+    Args:
+        url (str): URL to download file from
+        root (str): Directory to place downloaded file in
+        filename (str, optional): Name to save the file under. If None, use the basename of the URL
+        md5 (str, optional): MD5 checksum of the download. If None, do not check
+    """
+    import urllib
+
+    root = os.path.expanduser(root)
+    if not filename:
+        filename = os.path.basename(url)
+    fpath = os.path.join(root, filename)
+
+    os.makedirs(root, exist_ok=True)
+
+    # check if file is already present locally
+    if check_integrity(fpath, md5):
+        print('Using downloaded and verified file: ' + fpath)
+    else:   # download the file
+        try:
+            print('Downloading ' + url + ' to ' + fpath)
+            urllib.request.urlretrieve(
+                url, fpath,
+                reporthook=gen_bar_updater()
+            )
+        except (urllib.error.URLError, IOError) as e:  # type: ignore[attr-defined]
+            if url[:5] == 'https':
+                url = url.replace('https:', 'http:')
+                print('Failed download. Trying https -> http instead.'
+                      ' Downloading ' + url + ' to ' + fpath)
+                urllib.request.urlretrieve(
+                    url, fpath,
+                    reporthook=gen_bar_updater()
+                )
+            else:
+                raise e
+        # check integrity of downloaded file
+        if not check_integrity(fpath, md5):
+            raise RuntimeError("File not found or corrupted.")
+
+# From NIID-bench
+def download_and_extract_archive(
+    url: str,
+    download_root: str,
+    extract_root: Optional[str] = None,
+    filename: Optional[str] = None,
+    md5: Optional[str] = None,
+    remove_finished: bool = False,
+) -> None:
+    download_root = os.path.expanduser(download_root)
+    if extract_root is None:
+        extract_root = download_root
+    if not filename:
+        filename = os.path.basename(url)
+
+    download_url(url, download_root, filename, md5)
+
+    archive = os.path.join(download_root, filename)
+    print("Extracting {} to {}".format(archive, extract_root))
+    extract_archive(archive, extract_root, remove_finished)
+
+def _is_tarxz(filename: str) -> bool:
+    return filename.endswith(".tar.xz")
+
+
+def _is_tar(filename: str) -> bool:
+    return filename.endswith(".tar")
+
+
+def _is_targz(filename: str) -> bool:
+    return filename.endswith(".tar.gz")
+
+
+def _is_tgz(filename: str) -> bool:
+    return filename.endswith(".tgz")
+
+
+def _is_gzip(filename: str) -> bool:
+    return filename.endswith(".gz") and not filename.endswith(".tar.gz")
+
+
+def _is_zip(filename: str) -> bool:
+    return filename.endswith(".zip")
+
+def extract_archive(from_path: str, to_path: Optional[str] = None, remove_finished: bool = False) -> None:
+    if to_path is None:
+        to_path = os.path.dirname(from_path)
+
+    if _is_tar(from_path):
+        with tarfile.open(from_path, 'r') as tar:
+            def is_within_directory(directory, target):
+                
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+            
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                
+                return prefix == abs_directory
+            
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+            
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+            
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
+                
+            
+            safe_extract(tar, path=to_path)
+    elif _is_targz(from_path) or _is_tgz(from_path):
+        with tarfile.open(from_path, 'r:gz') as tar:
+            def is_within_directory(directory, target):
+                
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+            
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                
+                return prefix == abs_directory
+            
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+            
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+            
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
+                
+            
+            safe_extract(tar, path=to_path)
+    elif _is_tarxz(from_path):
+        with tarfile.open(from_path, 'r:xz') as tar:
+            def is_within_directory(directory, target):
+                
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+            
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                
+                return prefix == abs_directory
+            
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+            
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+            
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
+                
+            
+            safe_extract(tar, path=to_path)
+    elif _is_gzip(from_path):
+        to_path = os.path.join(to_path, os.path.splitext(os.path.basename(from_path))[0])
+        with open(to_path, "wb") as out_f, gzip.GzipFile(from_path) as zip_f:
+            out_f.write(zip_f.read())
+    elif _is_zip(from_path):
+        with zipfile.ZipFile(from_path, 'r') as z:
+            z.extractall(to_path)
+    else:
+        raise ValueError("Extraction of {} not supported".format(from_path))
+
+    if remove_finished:
+        os.remove(from_path)
+
+# From NIID-bench
+def mkdirs(dirpath):
+    try:
+        os.makedirs(dirpath)
+    except Exception as _:
+        pass
+
+# From NIID-bench
+class ImageFolder_custom(DatasetFolder):
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None, download=None):
+        self.root = root
+        self.dataidxs = dataidxs
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+
+        imagefolder_obj = ImageFolder(self.root, self.transform, self.target_transform)
+        self.loader = imagefolder_obj.loader
+        if self.dataidxs is not None:
+            self.samples = np.array(imagefolder_obj.samples)[self.dataidxs]
+        else:
+            self.samples = np.array(imagefolder_obj.samples)
+
+    def __getitem__(self, index):
+        path = self.samples[index][0]
+        target = self.samples[index][1]
+        target = int(target)
+        sample = self.loader(path)
+        if self.transform is not None:
+            sample = self.transform(sample)
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return sample, target
+
+    def __len__(self):
+        if self.dataidxs is None:
+            return len(self.samples)
+        else:
+            return len(self.dataidxs)
+
+# From NIID-bench
+
+# From NIID-bench
+class FashionMNIST_truncated(data.Dataset):
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None, download=False):
+
+        self.root = root
+        self.dataidxs = dataidxs
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+        self.download = download
+
+        self.data, self.target = self.__build_truncated_dataset__()
+
+    def __build_truncated_dataset__(self):
+
+        mnist_dataobj = FashionMNIST(self.root, self.train, self.transform, self.target_transform, self.download)
+
+        # if self.train:
+        #     data = mnist_dataobj.train_data
+        #     target = mnist_dataobj.train_labels
+        # else:
+        #     data = mnist_dataobj.test_data
+        #     target = mnist_dataobj.test_labels
+
+        data = mnist_dataobj.data
+        target = mnist_dataobj.targets
+
+        if self.dataidxs is not None:
+            data = data[self.dataidxs]
+            target = target[self.dataidxs]
+
+        return data, target
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index], self.target[index]
+
+        # doing this so that it is consistent with all other datasets
+        # to return a PIL Image
+        img = Image.fromarray(img.numpy(), mode='L')
+
+        # print("mnist img:", img)
+        # print("mnist target:", target)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+
+# From NIID-bench
+class CIFAR100_truncated(data.Dataset):
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None, download=False):
+
+        self.root = root
+        self.dataidxs = dataidxs
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+        self.download = download
+
+        self.data, self.target = self.__build_truncated_dataset__()
+
+    def __build_truncated_dataset__(self):
+
+        cifar_dataobj = CIFAR100(self.root, self.train, self.transform, self.target_transform, self.download)
+
+        if torchvision.__version__ == '0.2.1':
+            if self.train:
+                data, target = cifar_dataobj.train_data, np.array(cifar_dataobj.train_labels)
+            else:
+                data, target = cifar_dataobj.test_data, np.array(cifar_dataobj.test_labels)
+        else:
+            data = cifar_dataobj.data
+            target = np.array(cifar_dataobj.targets)
+
+        if self.dataidxs is not None:
+            data = data[self.dataidxs]
+            target = target[self.dataidxs]
+
+        return data, target
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index], self.target[index]
+        img = Image.fromarray(img)
+        # print("cifar10 img:", img)
+        # print("cifar10 target:", target)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+
+# From NIID-bench
+class CIFAR10_truncated(data.Dataset):
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None, download=False):
+
+        self.root = root
+        self.dataidxs = dataidxs
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+        self.download = download
+
+        self.data, self.target = self.__build_truncated_dataset__()
+
+    def __build_truncated_dataset__(self):
+
+        cifar_dataobj = CIFAR10(self.root, self.train, self.transform, self.target_transform, self.download)
+
+        data = cifar_dataobj.data
+        target = np.array(cifar_dataobj.targets)
+
+        if self.dataidxs is not None:
+            data = data[self.dataidxs]
+            target = target[self.dataidxs]
+
+        return data, target
+
+    def truncate_channel(self, index):
+        for i in range(index.shape[0]):
+            gs_index = index[i]
+            self.data[gs_index, :, :, 1] = 0.0
+            self.data[gs_index, :, :, 2] = 0.0
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index], self.target[index]
+
+        # print("cifar10 img:", img)
+        # print("cifar10 target:", target)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+# From NIID-bench
+def load_fmnist_data(datadir):
+
+    transform = transforms.Compose([transforms.ToTensor()])
+
+    mnist_train_ds = FashionMNIST_truncated(datadir, train=True, download=True, transform=transform)
+    mnist_test_ds = FashionMNIST_truncated(datadir, train=False, download=True, transform=transform)
+
+    X_train, y_train = mnist_train_ds.data, mnist_train_ds.target
+    X_test, y_test = mnist_test_ds.data, mnist_test_ds.target
+
+    X_train = X_train.data.numpy()
+    y_train = y_train.data.numpy()
+    X_test = X_test.data.numpy()
+    y_test = y_test.data.numpy()
+
+    return (X_train, y_train, X_test, y_test)
+
+# From NIID-bench
+class FEMNIST(MNIST):
+    """
+    This dataset is derived from the Leaf repository
+    (https://github.com/TalwalkarLab/leaf) pre-processing of the Extended MNIST
+    dataset, grouping examples by writer. Details about Leaf were published in
+    "LEAF: A Benchmark for Federated Settings" https://arxiv.org/abs/1812.01097.
+    """
+    resources = [
+        ('https://raw.githubusercontent.com/tao-shen/FEMNIST_pytorch/master/femnist.tar.gz',
+         '59c65cec646fc57fe92d27d83afdf0ed')]
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None,
+                 download=False):
+        super(MNIST, self).__init__(root, transform=transform,
+                                    target_transform=target_transform)
+        self.train = train
+        self.dataidxs = dataidxs
+
+        if download:
+            self.download()
+
+        if not self._check_exists():
+            raise RuntimeError('Dataset not found.' +
+                               ' You can use download=True to download it')
+        if self.train:
+            data_file = self.training_file
+        else:
+            data_file = self.test_file
+
+        self.data, self.targets, self.users_index = torch.load(os.path.join(self.processed_folder, data_file))
+
+        if self.dataidxs is not None:
+            self.data = self.data[self.dataidxs]
+            self.targets = self.targets[self.dataidxs]        
+
+
+    def __getitem__(self, index):
+        img, target = self.data[index], int(self.targets[index])
+        img = Image.fromarray(img.numpy(), mode='F')
+        if self.transform is not None:
+            img = self.transform(img)
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+        return img, target
+
+    def download(self):
+        """Download the FEMNIST data if it doesn't exist in processed_folder already."""
+        import shutil
+
+        if self._check_exists():
+            return
+
+        mkdirs(self.raw_folder)
+        mkdirs(self.processed_folder)
+
+        # download files
+        for url, md5 in self.resources:
+            filename = url.rpartition('/')[2]
+            download_and_extract_archive(url, download_root=self.raw_folder, filename=filename, md5=md5)
+
+        # process and save as torch files
+        print('Processing...')
+        shutil.move(os.path.join(self.raw_folder, self.training_file), self.processed_folder)
+        shutil.move(os.path.join(self.raw_folder, self.test_file), self.processed_folder)
+
+    def __len__(self):
+        return len(self.data)
+    
+    def _check_exists(self) -> bool:
+        return all(
+            check_integrity(os.path.join(self.raw_folder, os.path.splitext(os.path.basename(url))[0]+os.path.splitext(os.path.basename(url))[1]))
+            for url, _ in self.resources
+        )
+
+
+# From NIID-bench
+def load_mnist_data(datadir):
+
+    transform = transforms.Compose([transforms.ToTensor()])
+
+    mnist_train_ds = MNIST_truncated(datadir, train=True, download=True, transform=transform)
+    mnist_test_ds = MNIST_truncated(datadir, train=False, download=True, transform=transform)
+
+    X_train, y_train = mnist_train_ds.data, mnist_train_ds.target
+    X_test, y_test = mnist_test_ds.data, mnist_test_ds.target
+
+    X_train = X_train.data.numpy()
+    y_train = y_train.data.numpy()
+    X_test = X_test.data.numpy()
+    y_test = y_test.data.numpy()
+
+    return (X_train, y_train, X_test, y_test)
+
+# From NIID-bench
+def load_cifar10_data(datadir):
+
+    transform = transforms.Compose([transforms.ToTensor()])
+
+    cifar10_train_ds = CIFAR10_truncated(datadir, train=True, download=True, transform=transform)
+    cifar10_test_ds = CIFAR10_truncated(datadir, train=False, download=True, transform=transform)
+
+    X_train, y_train = cifar10_train_ds.data, cifar10_train_ds.target
+    X_test, y_test = cifar10_test_ds.data, cifar10_test_ds.target
+
+    # y_train = y_train.numpy()
+    # y_test = y_test.numpy()
+
+    return (X_train, y_train, X_test, y_test)
+
+def record_net_data_stats(y_train, net_dataidx_map):
+
+    net_cls_counts = {}
+    
+    for net_i, dataidx in net_dataidx_map.items():
+        unq, unq_cnt = np.unique(y_train[dataidx], return_counts=True)
+        tmp = {unq[i]: unq_cnt[i] for i in range(len(unq))}
+        net_cls_counts[net_i] = tmp
+        
+    dataframe = pd.DataFrame(net_cls_counts).T.fillna(0)
+    dataframe = dataframe.reindex(sorted(dataframe.columns), axis=1)
+    #dataframe.index += 1
+    #print(dataframe)
+
+    plt.title('Data Bins per client')
+    svm = sns.heatmap(dataframe, annot=True, fmt='g', cmap='rocket_r', square=True, linewidth=.5)
+    plt.xlabel('Class')
+    plt.ylabel('Client')
+    figure = svm.get_figure()
+    
+    directory = "databins"
+    if not os.path.exists(directory):
+        # If it doesn't exist, create it
+        os.makedirs(directory)
+        
+    figure.savefig(f'{directory}/heatmap.png', dpi=400)
+    
+    #logger.info('Data statistics: %s' % str(net_cls_counts))
+    #logger.info('Saved Data bins Heatmap')
+
+    return net_cls_counts
+
+'''
+generate partion for extrem label skew 
+Used code from NIID-Benchmark
+'''
+def partition_data_label_skew(dataset, datadir, partition, n_parties, beta=0.4):
+    #np.random.seed(2020)
+    #torch.manual_seed(2020)
+
+    if dataset == 'mnist':
+        X_train, y_train, X_test, y_test = load_mnist_data(datadir)
+    elif dataset == 'fmnist':
+        X_train, y_train, X_test, y_test = load_fmnist_data(datadir)
+    elif dataset == 'CIFAR10':
+        X_train, y_train, X_test, y_test = load_cifar10_data(datadir)
+
+    n_train = y_train.shape[0]
+
+    if partition == "homo": # feature distribution - noise 
+        idxs = np.random.permutation(n_train)
+        batch_idxs = np.array_split(idxs, n_parties)
+        net_dataidx_map = {i: batch_idxs[i] for i in range(n_parties)}
+
+
+    elif partition == "noniid-labeldir": #label-distribution skew - distribution
+        min_size = 0
+        min_require_size = 10
+        K = 10 # number of samples
+        if dataset in ('celeba', 'covtype', 'a9a', 'rcv1', 'SUSY'):
+            K = 2
+            # min_require_size = 100
+        if dataset == 'cifar100':
+            K = 100
+        elif dataset == 'tinyimagenet':
+            K = 200
+
+        N = y_train.shape[0]
+        #np.random.seed(2020)
+        net_dataidx_map = {}
+
+        while min_size < min_require_size:
+            idx_batch = [[] for _ in range(n_parties)]
+            for k in range(K):
+                idx_k = np.where(y_train == k)[0]
+                np.random.shuffle(idx_k)
+                proportions = np.random.dirichlet(np.repeat(beta, n_parties))
+                ## Balance
+                proportions = np.array([p * (len(idx_j) < N / n_parties) for p, idx_j in zip(proportions, idx_batch)])
+                proportions = proportions / proportions.sum()
+                proportions = (np.cumsum(proportions) * len(idx_k)).astype(int)[:-1]
+                idx_batch = [idx_j + idx.tolist() for idx_j, idx in zip(idx_batch, np.split(idx_k, proportions))]
+                min_size = min([len(idx_j) for idx_j in idx_batch])
+
+        for j in range(n_parties):
+            np.random.shuffle(idx_batch[j])
+            net_dataidx_map[j] = idx_batch[j]
+
+    elif partition > "noniid-#label0" and partition <= "noniid-#label9": #label-distribution skew - quantity
+        num = eval(partition[13:])
+        #print(f'the num is {num}')
+        if dataset in ('celeba', 'covtype', 'a9a', 'rcv1', 'SUSY'):
+            num = 1
+            K = 2
+        else:
+            K = 10
+        if dataset == "cifar100":
+            K = 100
+        elif dataset == "tinyimagenet":
+            K = 200
+        if num == 10:
+            net_dataidx_map ={i:np.ndarray(0,dtype=np.int64) for i in range(n_parties)}
+            for i in range(10):
+                idx_k = np.where(y_train==i)[0]
+                np.random.shuffle(idx_k)
+                split = np.array_split(idx_k,n_parties)
+                for j in range(n_parties):
+                    net_dataidx_map[j]=np.append(net_dataidx_map[j],split[j])
+        else:
+            times=[0 for i in range(K)]
+            contain=[]
+            used = []
+            #NOTE:  if num < k/_parties is there any point of that?
+            if num == int(K/n_parties):
+                for i in range(n_parties):
+                    current=[i%K]
+                    used.append(i%K) 
+                    times[i%K]+=1
+                    j=1
+                    while (j<num):
+                        ind=random.randint(0,K-1)
+                        if ((ind not in current )and (ind not in used)):
+                            j=j+1
+                            current.append(ind)
+                            used.append(ind) 
+                            times[ind]+=1
+                    contain.append(current)
+            
+            else:
+                for i in range(n_parties):
+                    current=[i%K]
+                    times[i%K]+=1
+                    j=1
+                    while (j<num):
+                        ind=random.randint(0,K-1)
+                        if (ind not in current):
+                            j=j+1
+                            current.append(ind)
+                            times[ind]+=1
+                    contain.append(current)
+            net_dataidx_map ={i:np.ndarray(0,dtype=np.int64) for i in range(n_parties)}
+            for i in range(K):
+                idx_k = np.where(y_train==i)[0]
+                np.random.shuffle(idx_k)
+                split = np.array_split(idx_k,times[i])
+                ids=0
+                for j in range(n_parties):
+                    if i in contain[j]:
+                        net_dataidx_map[j]=np.append(net_dataidx_map[j],split[ids])
+                        ids+=1
+        
+    traindata_cls_counts = record_net_data_stats(y_train, net_dataidx_map)
+    return (X_train, y_train, X_test, y_test, net_dataidx_map, traindata_cls_counts)
+
+class Generated(MNIST):
+
+    def __init__(self, root, dataidxs=None, train=True, transform=None, target_transform=None,
+                 download=False):
+        super(MNIST, self).__init__(root, transform=transform,
+                                    target_transform=target_transform)
+        self.train = train
+        self.dataidxs = dataidxs
+
+        if self.train:
+            self.data = np.load("data/generated/X_train.npy")
+            self.targets = np.load("data/generated/y_train.npy")
+        else:
+            self.data = np.load("data/generated/X_test.npy")
+            self.targets = np.load("data/generated/y_test.npy")            
+
+        if self.dataidxs is not None:
+            self.data = self.data[self.dataidxs]
+            self.targets = self.targets[self.dataidxs]        
+
+
+    def __getitem__(self, index):
+        data, target = self.data[index], self.targets[index]
+        return data, target
+
+    def __len__(self):
+        return len(self.data)
+
+
+# From NIID-bench
+class AddGaussianNoise(object):
+    def __init__(self, mean=0., std=1., net_id=None, total=0):
+        self.std = std
+        self.mean = mean
+        self.net_id = net_id
+        self.num = int(sqrt(total))
+        if self.num * self.num < total:
+            self.num = self.num + 1
+
+    def __call__(self, tensor):
+        if self.net_id is None:
+            return tensor + torch.randn(tensor.size()) * self.std + self.mean
+        else:
+            tmp = torch.randn(tensor.size())
+            filt = torch.zeros(tensor.size())
+            size = int(28 / self.num)
+            row = int(self.net_id / size)
+            col = self.net_id % size
+            for i in range(size):
+                for j in range(size):
+                    filt[:,row*size+i,col*size+j] = 1
+            tmp = tmp * filt
+            return tensor + tmp * self.std + self.mean
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(mean={0}, std={1})'.format(self.mean, self.std)
+    
+# From NIID-bench
+def get_dataloader_skew(dataset, datadir, train_bs, test_bs, dataidxs=None, noise_level=0, net_id=None, total=0, model='alexnet'):
+    if dataset in ('mnist', 'femnist', 'fmnist', 'CIFAR10', 'svhn', 'generated', 'covtype', 'a9a', 'rcv1', 'SUSY', 'cifar100', 'tinyimagenet'):
+        if dataset == 'mnist':
+            dl_obj = MNIST_truncated
+
+            transform_train = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+
+            transform_test = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+
+        elif dataset == 'femnist':
+            dl_obj = FEMNIST
+            transform_train = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+            transform_test = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+
+        elif dataset == 'fmnist':
+            dl_obj = FashionMNIST_truncated
+            transform_train = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+            transform_test = transforms.Compose([
+                transforms.ToTensor(),
+                AddGaussianNoise(0., noise_level, net_id, total)])
+        elif dataset == 'CIFAR10':
+            dl_obj = CIFAR10_truncated
+            if model == 'AlexNet':
+                transform_train = transforms.Compose([
+                    transforms.ToTensor(),
+                    transforms.Lambda(lambda x: F.pad(
+                        Variable(x.unsqueeze(0), requires_grad=False),
+                        (4, 4, 4, 4), mode='reflect').data.squeeze()),
+                    transforms.ToPILImage(),
+                    transforms.RandomCrop(32),
+                    transforms.RandomHorizontalFlip(),
+                    transforms.ToTensor(),
+                    AddGaussianNoise(0., noise_level, net_id, total),
+                    transforms.Resize((70, 70))
+                ])
+                # data prep for test set
+                transform_test = transforms.Compose([
+                    transforms.ToTensor(),
+                    AddGaussianNoise(0., noise_level, net_id, total),
+                    transforms.Resize((70, 70))])
+            else:
+                transform_train = transforms.Compose([
+                    transforms.ToTensor(),
+                    transforms.Lambda(lambda x: F.pad(
+                        Variable(x.unsqueeze(0), requires_grad=False),
+                        (4, 4, 4, 4), mode='reflect').data.squeeze()),
+                    transforms.ToPILImage(),
+                    transforms.RandomCrop(32),
+                    transforms.RandomHorizontalFlip(),
+                    transforms.ToTensor(),
+                    AddGaussianNoise(0., noise_level, net_id, total)
+                ])
+                # data prep for test set
+                transform_test = transforms.Compose([
+                    transforms.ToTensor(),
+                    AddGaussianNoise(0., noise_level, net_id, total)])
+            
+        elif dataset == 'cifar100':
+            dl_obj = CIFAR100_truncated
+
+            normalize = transforms.Normalize(mean=[0.5070751592371323, 0.48654887331495095, 0.4409178433670343],
+                                             std=[0.2673342858792401, 0.2564384629170883, 0.27615047132568404])
+            
+            transform_train = transforms.Compose([
+                # transforms.ToPILImage(),
+                transforms.RandomCrop(32, padding=4),
+                transforms.RandomHorizontalFlip(),
+                transforms.RandomRotation(15),
+                transforms.ToTensor(),
+                normalize
+            ])
+            # data prep for test set
+            transform_test = transforms.Compose([
+                transforms.ToTensor(),
+                normalize])
+        elif dataset == 'tinyimagenet':
+            dl_obj = ImageFolder_custom
+            transform_train = transforms.Compose([
+                transforms.Resize(32), 
+                transforms.RandomCrop(32, padding=4),
+                transforms.RandomHorizontalFlip(),
+                transforms.RandomRotation(15),
+                transforms.ToTensor(),
+                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            ])
+            transform_test = transforms.Compose([
+                transforms.Resize(32), 
+                transforms.ToTensor(),
+                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            ])
+
+        else:
+            dl_obj = Generated
+            transform_train = None
+            transform_test = None
+
+
+        if dataset == "tinyimagenet":
+            train_ds = dl_obj(datadir+'./train/', dataidxs=dataidxs, transform=transform_train)
+            test_ds = dl_obj(datadir+'./val/', transform=transform_test)
+        else:
+            train_ds = dl_obj(datadir, dataidxs=dataidxs, train=True, transform=transform_train, download=True)
+            test_ds = dl_obj(datadir, train=False, transform=transform_test, download=True)
+
+        train_dl = data.DataLoader(dataset=train_ds, batch_size=train_bs, shuffle=True, drop_last=False)
+        # DataLoader(dataset=train_ds, batch_size=train_bs, shuffle=True, drop_last=False)
+        test_dl = data.DataLoader(dataset=test_ds, batch_size=test_bs, shuffle=False, drop_last=False)
+
+    return train_dl, test_dl, train_ds, test_ds

--- a/experiment.py
+++ b/experiment.py
@@ -186,6 +186,7 @@ def main():
     client_train_loader = []
     for worker_idx in range(worker_num):
         if args.type_noniid != 'label_skew' and labels:
+            print(f'for worker {worker_idx}')
             client_train_loader.append(datasets.create_dataloaders(train_dataset, batch_size=int(bsz_list[worker_idx]), selected_idxs=train_data_partition.use(worker_idx), pin_memory=False, drop_last=True, collate_fn=lambda x: datasets.collate_fn(x, labels)))
         elif args.type_noniid == 'label_skew':
             dataidxs_ = net_dataidx_map[worker_idx]

--- a/experiment.py
+++ b/experiment.py
@@ -30,7 +30,7 @@ parser.add_argument('--data_path', type=str, default='./data')
 parser.add_argument('--device', type=str, default='cpu', help='The device to run the program') #cpu
 parser.add_argument('--expname', type=str, default='MergeSFL')
 parser.add_argument('--two_splits', action="store_true", help='do U-Shape')
-parser.add_argument('--type_noniid', type=str, default='default')
+parser.add_argument('--type_noniid', type=str, default='default') # label_skew
 parser.add_argument('--level', type=str, default='noniid-#label1')
 
 
@@ -306,7 +306,8 @@ def main():
                     # server sends grad_a to individual workers
                     my_outas[worker_idx].backward(grad_a)
                     client_optimizers_first[worker_idx].step()
-                index_data = (index_data+1) %  len(client_train_loader[0])
+                if args.type_noniid == 'label_skew':
+                    index_data = (index_data+1) %  len(client_train_loader[0])
             else:
                 clients_smash_data = []
                 clients_send_data = []
@@ -356,7 +357,8 @@ def main():
                     clients_optimizers[worker_idx].zero_grad()
                     clients_smash_data[worker_idx].backward(clients_grad.to(device))
                     clients_optimizers[worker_idx].step()
-                index_data = (index_data+1) %  len(client_train_loader[0])
+                if args.type_noniid == 'label_skew':
+                    index_data = (index_data+1) %  len(client_train_loader[0])
         # AGGREGATION
         with torch.no_grad():
             for worker_idx in range(worker_num):

--- a/experiment.py
+++ b/experiment.py
@@ -124,7 +124,7 @@ def partition_data_non_iid_strict(dataset_type, data_pattern, worker_num=10):
 
 def main():
     print('OKKK')
-    #args = parser.parse_args()
+    args = parser.parse_args()
     #device = torch.device(args.device)
     torch.manual_seed(42)
     worker_num = args.worker_num
@@ -133,6 +133,7 @@ def main():
     if args.two_splits:
         m = 4
         if args.type_noniid == 'label_skew':
+            print('OKKK2')
             m = 8
         
         client_global_model, server_global_model = models.create_model_instance_SL_two_splits(args.dataset_type, args.model_type, 1, m=m)
@@ -165,8 +166,10 @@ def main():
     if args.type_noniid == 'default':
         train_dataset, test_dataset, train_data_partition, labels = partition_data(args.dataset_type, args.data_pattern, worker_num)
     elif args.type_noniid == 'label_skew':
+        print('OKKK3')
         X_train, y_train, X_test, y_test, net_dataidx_map, traindata_cls_counts = datasets.partition_data_label_skew(
         args.dataset_type, './data', args.level, worker_num)
+        print('OKKK4')
         labels = False
     else:
         train_dataset, test_dataset, train_data_partition, labels = partition_data_non_iid_strict(args.dataset_type, args.data_pattern, worker_num)
@@ -177,8 +180,10 @@ def main():
         else:
             test_loader = datasets.create_dataloaders(test_dataset, batch_size=64, shuffle=False)
     else:
+        print('OKKK5')
         train_dl_local_, test_dl_local, _, _ = datasets.get_dataloader_skew(args.dataset_type, './data', args.batch_size, 32, model=args.model_type)
         test_loader = test_dl_local
+        print('OKKK6')
 
     # Clients data loaders
     bsz_list = np.ones(worker_num, dtype=int) * args.batch_size

--- a/experiment.py
+++ b/experiment.py
@@ -125,7 +125,7 @@ def partition_data_non_iid_strict(dataset_type, data_pattern, worker_num=10):
 def main():
     print('OKKK')
     args = parser.parse_args()
-    #device = torch.device(args.device)
+    device = torch.device(args.device)
     torch.manual_seed(42)
     worker_num = args.worker_num
     print(args.__dict__)

--- a/experiment.py
+++ b/experiment.py
@@ -7,7 +7,6 @@ import copy
 import torch.nn.functional as F
 import datasets, models
 import torch.optim as optim
-import logging
 from training_utils import *
 from torch.utils.tensorboard import SummaryWriter
 
@@ -33,9 +32,6 @@ parser.add_argument('--two_splits', action="store_true", help='do U-Shape')
 parser.add_argument('--type_noniid', type=str, default='default') # label_skew
 parser.add_argument('--level', type=str, default='noniid-#label1')
 
-
-args = parser.parse_args()
-device = torch.device(args.device)
 
 def non_iid_partition(ratio, train_class_num, worker_num):
     partition_sizes = np.ones((train_class_num, worker_num)) * ((1 - ratio) / (worker_num-1))
@@ -127,6 +123,9 @@ def partition_data_non_iid_strict(dataset_type, data_pattern, worker_num=10):
     return train_dataset, test_dataset, train_data_partition, labels
 
 def main():
+    print('OKKK')
+    args = parser.parse_args()
+    device = torch.device(args.device)
     torch.manual_seed(42)
     worker_num = args.worker_num
     print(args.__dict__)

--- a/experiment.py
+++ b/experiment.py
@@ -31,7 +31,7 @@ parser.add_argument('--device', type=str, default='cpu', help='The device to run
 parser.add_argument('--expname', type=str, default='MergeSFL')
 parser.add_argument('--two_splits', action="store_true", help='do U-Shape')
 parser.add_argument('--type_noniid', type=str, default='default')
-parser.add_argument('--level', type=int, default=10)
+parser.add_argument('--level', type=str, default='noniid-#label1')
 
 
 args = parser.parse_args()
@@ -132,8 +132,12 @@ def main():
     print(args.__dict__)
 
     if args.two_splits:
-        client_global_model, server_global_model = models.create_model_instance_SL_two_splits(args.dataset_type, args.model_type, 1)
-        nets, _ = models.create_model_instance_SL_two_splits(args.dataset_type, args.model_type, worker_num)
+        m = 4
+        if args.type_noniid == 'label_skew':
+            m = 8
+        
+        client_global_model, server_global_model = models.create_model_instance_SL_two_splits(args.dataset_type, args.model_type, 1, m=m)
+        nets, _ = models.create_model_instance_SL_two_splits(args.dataset_type, args.model_type, worker_num, m=m)
 
         client_global_model_first = client_global_model[0][0]
         client_global_model_last = client_global_model[0][1]
@@ -146,8 +150,12 @@ def main():
             net[0].load_state_dict(global_model_par_first)
             net[1].load_state_dict(global_model_par_last)
     else:
-        client_global_model, server_global_model = models.create_model_instance_SL(args.dataset_type, args.model_type, 1)
-        nets, _ = models.create_model_instance_SL(args.dataset_type, args.model_type, worker_num)
+        m = 4
+        if args.type_noniid == 'label_skew':
+            m = 8
+
+        client_global_model, server_global_model = models.create_model_instance_SL(args.dataset_type, args.model_type, 1, m=m)
+        nets, _ = models.create_model_instance_SL(args.dataset_type, args.model_type, worker_num, m=m)
 
         client_global_model = client_global_model[0]
         global_model_par = client_global_model.state_dict()
@@ -157,20 +165,32 @@ def main():
     # Create model instance
     if args.type_noniid == 'default':
         train_dataset, test_dataset, train_data_partition, labels = partition_data(args.dataset_type, args.data_pattern, worker_num)
+    elif args.type_noniid == 'label_skew':
+        X_train, y_train, X_test, y_test, net_dataidx_map, traindata_cls_counts = datasets.partition_data_label_skew(
+        args.dataset_type, './data', args.level, worker_num)
+        labels = False
     else:
         train_dataset, test_dataset, train_data_partition, labels = partition_data_non_iid_strict(args.dataset_type, args.data_pattern, worker_num)
-
-    if labels:
-        test_loader = datasets.create_dataloaders(test_dataset, batch_size=64, shuffle=False, collate_fn=lambda x: datasets.collate_fn(x, labels))
+        
+    if args.type_noniid != 'label_skew':
+        if labels:
+            test_loader = datasets.create_dataloaders(test_dataset, batch_size=64, shuffle=False, collate_fn=lambda x: datasets.collate_fn(x, labels))
+        else:
+            test_loader = datasets.create_dataloaders(test_dataset, batch_size=64, shuffle=False)
     else:
-        test_loader = datasets.create_dataloaders(test_dataset, batch_size=64, shuffle=False)
+        train_dl_local_, test_dl_local, _, _ = datasets.get_dataloader_skew(args.dataset_type, './data', args.batch_size, 32, model=args.model_type)
+        test_loader = test_dl_local
 
     # Clients data loaders
     bsz_list = np.ones(worker_num, dtype=int) * args.batch_size
     client_train_loader = []
     for worker_idx in range(worker_num):
-        if labels:
+        if args.type_noniid != 'label_skew' and labels:
             client_train_loader.append(datasets.create_dataloaders(train_dataset, batch_size=int(bsz_list[worker_idx]), selected_idxs=train_data_partition.use(worker_idx), pin_memory=False, drop_last=True, collate_fn=lambda x: datasets.collate_fn(x, labels)))
+        elif args.type_noniid == 'label_skew':
+            dataidxs_ = net_dataidx_map[worker_idx]
+            train_dl_local_, test_dl_local, _, _ = datasets.get_dataloader_skew(args.dataset_type, './data', args.batch_size, 32, dataidxs_, 0, model=args.model_type)
+            client_train_loader.append(train_dl_local_)
         else:
             print(f'for worker {worker_idx}')
             client_train_loader.append(datasets.create_dataloaders(train_dataset, batch_size=int(bsz_list[worker_idx]), selected_idxs=train_data_partition.use(worker_idx), pin_memory=False, drop_last=True))
@@ -178,7 +198,9 @@ def main():
     epoch_client_lr = args.client_lr
     epoch_server_lr = args.server_lr
     print('Start training')
+    index_data = 0
     for epoch_idx in range(1, 1 + args.epoch):
+        
         print(f'In epoch:{epoch_idx}')
         start_time = time.time()
         # Learning rate adjustment
@@ -224,7 +246,10 @@ def main():
                 my_outas = []
                 clients_part1_send_targets = []
                 for worker_idx in range(worker_num):
-                    inputs, targets = next(client_train_loader[worker_idx])
+                    if args.type_noniid != 'label_skew':
+                        inputs, targets = next(client_train_loader[worker_idx])
+                    else:
+                        inputs, targets = client_train_loader[worker_idx][index_data]
 
                     inputs, targets = inputs.to(device), targets.to(device) 
                     clients_part1_send_targets.append(targets)
@@ -281,7 +306,7 @@ def main():
                     # server sends grad_a to individual workers
                     my_outas[worker_idx].backward(grad_a)
                     client_optimizers_first[worker_idx].step()
-
+                index_data = (index_data+1) %  len(client_train_loader[0])
             else:
                 clients_smash_data = []
                 clients_send_data = []
@@ -289,7 +314,10 @@ def main():
 
                 sum_bsz = sum([bsz_list[i] for i in range(worker_num)])
                 for worker_idx in range(worker_num):
-                    inputs, targets = next(client_train_loader[worker_idx])
+                    if args.type_noniid != 'label_skew':
+                        inputs, targets = next(client_train_loader[worker_idx])
+                    else:
+                        inputs, targets = next(iter(client_train_loader[worker_idx]))
 
                     inputs, targets = inputs.to(device), targets.to(device)
 
@@ -302,14 +330,14 @@ def main():
                     clients_send_targets.append(targets)
                 
                 m_data = torch.cat(clients_send_data, dim=0)
-                print(f'combined data shape:{m_data.shape}')
+                #print(f'combined data shape:{m_data.shape}')
                 m_target = torch.cat(clients_send_targets, dim=0)
 
                 m_data.requires_grad_()
 
                 # server side fp
                 outputs = server_global_model(m_data)
-                print(f'output shape:{outputs.shape}')
+                #print(f'output shape:{outputs.shape}')
 
                 loss = F.cross_entropy(outputs, m_target.long())
 
@@ -328,7 +356,7 @@ def main():
                     clients_optimizers[worker_idx].zero_grad()
                     clients_smash_data[worker_idx].backward(clients_grad.to(device))
                     clients_optimizers[worker_idx].step()
-
+                index_data = (index_data+1) %  len(client_train_loader[0])
         # AGGREGATION
         with torch.no_grad():
             for worker_idx in range(worker_num):
@@ -367,10 +395,14 @@ def main():
                     client_global_model.load_state_dict(global_model_par)
         
         server_global_model.to('cpu')
-        if args.two_splits:
-            test_loss, acc = test((client_global_model_first, client_global_model_last), server_global_model, test_loader, two_split=args.two_splits)
+        if args.type_noniid != 'label_skew':
+            test_loader_ = test_loader.loader
         else:
-            test_loss, acc = test(client_global_model, server_global_model, test_loader, two_split=args.two_splits)
+            test_loader_ = test_loader
+        if args.two_splits:
+            test_loss, acc = test((client_global_model_first, client_global_model_last), server_global_model, test_loader_, two_split=args.two_splits)
+        else:
+            test_loss, acc = test(client_global_model, server_global_model, test_loader_, two_split=args.two_splits)
         print("Epoch: {}, accuracy: {}, test_loss: {}".format(epoch_idx, acc, test_loss))
 
         if args.two_splits:

--- a/experiment.py
+++ b/experiment.py
@@ -124,8 +124,8 @@ def partition_data_non_iid_strict(dataset_type, data_pattern, worker_num=10):
 
 def main():
     print('OKKK')
-    args = parser.parse_args()
-    device = torch.device(args.device)
+    #args = parser.parse_args()
+    #device = torch.device(args.device)
     torch.manual_seed(42)
     worker_num = args.worker_num
     print(args.__dict__)

--- a/experiment.py
+++ b/experiment.py
@@ -249,7 +249,7 @@ def main():
                     if args.type_noniid != 'label_skew':
                         inputs, targets = next(client_train_loader[worker_idx])
                     else:
-                        inputs, targets = client_train_loader[worker_idx][index_data]
+                        inputs, targets = next(iter(client_train_loader[worker_idx]))
 
                     inputs, targets = inputs.to(device), targets.to(device) 
                     clients_part1_send_targets.append(targets)

--- a/models.py
+++ b/models.py
@@ -2,13 +2,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-def create_model_instance_SL(dataset_type, model_type, worker_num, class_num=10):
+def create_model_instance_SL(dataset_type, model_type, worker_num, class_num=10, m=4):
     client_nets = {net_i: None for net_i in range(worker_num)}
 
     if dataset_type == 'CIFAR10':
-        server = AlexNet_U_Shape(2, -1, class_num)
+        server = AlexNet_U_Shape(2, -1, class_num, m=m)
         for net_i in range(worker_num):
-            net = AlexNet_U_Shape(0, 2, class_num)
+            net = AlexNet_U_Shape(0, 2, class_num, m=m)
             client_nets[net_i] = net
         return client_nets, server
 
@@ -33,13 +33,13 @@ def create_model_instance_SL(dataset_type, model_type, worker_num, class_num=10)
             client_nets[net_i] = net
         return client_nets, server
 
-def create_model_instance_SL_two_splits(dataset_type, model_type, worker_num, class_num=10):
+def create_model_instance_SL_two_splits(dataset_type, model_type, worker_num, class_num=10, m=4):
     client_nets = {net_i: None for net_i in range(worker_num)}
 
     if dataset_type == 'CIFAR10':
-        server = AlexNet_U_Shape(2, 4, class_num)
+        server = AlexNet_U_Shape(2, 4, class_num, m=m)
         for net_i in range(worker_num):
-            net = (AlexNet_U_Shape(0, 2, class_num), AlexNet_U_Shape(4, -1, class_num))
+            net = (AlexNet_U_Shape(0, 2, class_num, m=m), AlexNet_U_Shape(4, -1, class_num, m=m))
             client_nets[net_i] = net
         return client_nets, server
 
@@ -65,7 +65,7 @@ def create_model_instance_SL_two_splits(dataset_type, model_type, worker_num, cl
         return client_nets, server
 
 class AlexNet_U_Shape(nn.Module):
-    def __init__(self, first_cut=-1, last_cut=-1, class_num=10):
+    def __init__(self, first_cut=-1, last_cut=-1, class_num=10, m=4):
         super(AlexNet_U_Shape, self).__init__()
         self.first_cut = first_cut
         self.last_cut = last_cut
@@ -99,7 +99,7 @@ class AlexNet_U_Shape(nn.Module):
 
         self.fc_layers = [
             nn.Dropout(),
-            nn.Linear(256 * 4 * 4, 4096),
+            nn.Linear(256 * m * m, 4096),
             nn.ReLU(inplace=True),
             nn.Dropout(),
             nn.Linear(4096, 4096),

--- a/training_utils.py
+++ b/training_utils.py
@@ -12,7 +12,7 @@ def test(model_fe, model_p, data_loader, device=torch.device("cpu"), two_split=F
     else: 
         model_fe.eval()
 
-    data_loader = data_loader.loader
+    #data_loader = data_loader.loader
     test_loss = 0.0
     test_accuracy = 0.0
     correct = 0


### PR DESCRIPTION
Now we can run experiments with strict label-skew:

Summary of changes:

1. In the arguments the type_noniid is 'default' when using the current type of data partition, if you define it as 'label_skew' then we will partition the data to the clients according to the NIID bench.
2. In the arguments level is used to define the level of label skewness defined as 'noniid-#labelx' where x is the number of targets each of the clients is going to have. For example if 'noniid-#label1', that means that each client receives only samples from one label.
3. Inside the dataset.py, added the functions that the NONIID bench uses to build the dataloaders
4. changed some things in the flow of the experiment in order to support both configurations
5. In models for alexnet I have to change one of the fully connected layers dimension because noniid applies a different transformation.